### PR TITLE
Update aiofiles version to 25.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles==24.1.0
+aiofiles==25.1.0
 anyio==4.11.0
 attrs==25.4.0
 autocommand==2.2.2


### PR DESCRIPTION
Astrbot 上游更新了包 aiofiles 的版本，requirements.txt 仍未同步这个变动，这会导致该插件无法在新版 Astrbot 上运行，现修改 requirements.txt 与 Astrbot 兼容。